### PR TITLE
console.vespa.ai's redirect does not support https yet

### DIFF
--- a/automated-deployments.html
+++ b/automated-deployments.html
@@ -93,7 +93,7 @@ negatively, typically by asserting on application metrics after a delay. If the 
 zones, this makes it possible to revert to the old version quickly by shifting traffic to another production zone.
 </p><p>
 Status of ongoing tests and deployments is found by clicking <em>Deployment</em> in the application view in the
-<a href="https://console.vespa.ai">console</a>. <!--It is possible to delay the deployment to a region
+<a href="http://console.vespa.ai">console</a>. <!--It is possible to delay the deployment to a region
 by clicking the <em>pause</em> button, and to force through a deployment by clicking the <em>deploy</em> button. -->
 Examples of advanced deployment configuration which can be set in
 <a href="/reference/deployment">deployment.xml</a> include:

--- a/reference/vespa-cloud-api.html
+++ b/reference/vespa-cloud-api.html
@@ -4,7 +4,7 @@ title: Vespa cloud API
 
 <p>The Vespa APIs are described in detail in the <a href="https://docs.vespa.ai">general documentation</a>.
 This document describes the additional APIs of the Vespa cloud that a Vespa application developer needs,
-in addition to the <a href="https://console.vespa.ai">Vespa cloud console</a>.,
+in addition to the <a href="http://console.vespa.ai">Vespa cloud console</a>.,
 to deploy an application to <a href="/automated-deployments">production</a> or during
 <a href="/reference/environments">development</a> for <a href="/automated-deployments#system-tests">testing</a> purposes.</p>
 


### PR DESCRIPTION
When we link to `console.vespa.ai`, we must use https-less links.