### PR TITLE
Add last updated timestamp to status JSON

### DIFF
--- a/status.json
+++ b/status.json
@@ -2,4 +2,7 @@
 layout: status
 # Data for this page is found in _data/status.yml
 ---
-{{ site.data.status | jsonify }}
+{
+	"last-updated": "{{ "now" | date: "%s" }}",
+	"status": {{ site.data.status | jsonify }}
+}


### PR DESCRIPTION
Adding "last updated" information to JSON output. Unfortunately, I wasn't able to add this information into the existing JSON structure, so I needed to wrap the previous status info into an additional `status` JSON object.

New format:
```javascript
{
    "last-update": "1587726680",
    "status": {
        "messages": [
            {
                "date": "2020-03-23",
                "message": "The aws-ap-northeast-1a zone in Tokyo, JP region is now online!"
            }
        ],
        "zones": [
            {
                "message": "OK",
                "name": "Infrastructure",
                "status": "success"
            },
            {
                "message": "OK",
                "name": "aws-us-east-1c",
                "status": "success"
            },
            {
                "message": "OK",
                "name": "aws-ap-northeast-1a",
                "status": "success"
            }
        ]
    }
}
```