### PR TITLE
add generate link

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -108,7 +108,8 @@ A certificate is also generated below.
     </li>
     <li>
         <p>
-        <strong>Download the
+        <strong>Copy repo using <a href="https://github.com/vespa-engine/sample-apps/generate">
+        github.com/vespa-engine/sample-apps/generate</a>, or download the repo with the
             <a href="https://github.com/vespa-engine/sample-apps/tree/master/vespa-cloud/album-recommendation">album-recommendation</a>
             sample app</strong>
 <pre>


### PR DESCRIPTION
cannot easily replace the git clone, as the auto testing uses it - and the repo must be cloned from somewhere anyway - so maybe this is best compromise