### PR TITLE
footer/header and guide/ref doc links

### DIFF
--- a/_includes/footer-wide.html
+++ b/_includes/footer-wide.html
@@ -7,19 +7,27 @@
                 <div class="col-md-2">
                     <ul class="nav footer-text">
                         <li>RESOURCES</li>
-                        <li><a href="https://docs.vespa.ai/documentation/getting-started.html">Getting Started</a></li>
-                        <li><a href="https://docs.vespa.ai">Documentation</a></li>
+                        <li><a href="/getting-started">Getting Started</a></li>
+                        <li><a href="/reference-documentation">Reference Documentation</a></li>
                         <li><a href="https://github.com/vespa-engine/vespa">Open source</a></li>
                     </ul>
                 </div>
                 <div class="col-md-2">
                     <ul class="nav footer-text">
-                        <li>CONTACT</li>
-                        <li><a href="support">Support</a></li>
+                        <li>CLOUD</li>
+                        <li><a href="/pricing">Pricing</a></li>
+                        <li><a href="/support">Support</a></li>
+                        <li><a href="/use-cases">Use Cases</a></li>
+                    </ul>
+                </div>
+                <div class="col-md-2">
+                    <ul class="nav footer-text">
+                        <li>NEWS</li>
+                        <li><a href="https://blog.vespa.ai">Blog</a></li>
                         <li><a href="https://twitter.com/vespaengine">Twitter</a></li>
                     </ul>
                 </div>
-                <div class="col-md-8">
+                <div class="col-md-6">
                     <ul class="nav footer-text text-right">
                         <li>
                             <p>Copyright Verizon Media. All rights reserved.</p>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,19 +6,27 @@
                 <div class="col-md-2">
                     <ul class="nav footer-text">
                         <li>RESOURCES</li>
-                        <li><a href="https://docs.vespa.ai/documentation/getting-started.html">Getting Started</a></li>
-                        <li><a href="https://docs.vespa.ai">Documentation</a></li>
+                        <li><a href="/getting-started">Getting Started</a></li>
+                        <li><a href="/reference-documentation">Reference Documentation</a></li>
                         <li><a href="https://github.com/vespa-engine/vespa">Open source</a></li>
                     </ul>
                 </div>
                 <div class="col-md-2">
                     <ul class="nav footer-text">
-                        <li>CONTACT</li>
-                        <li><a href="support">Support</a></li>
+                        <li>CLOUD</li>
+                        <li><a href="/pricing">Pricing</a></li>
+                        <li><a href="/support">Support</a></li>
+                        <li><a href="/use-cases">Use Cases</a></li>
+                    </ul>
+                </div>
+                <div class="col-md-2">
+                    <ul class="nav footer-text">
+                        <li>NEWS</li>
+                        <li><a href="https://blog.vespa.ai">Blog</a></li>
                         <li><a href="https://twitter.com/vespaengine">Twitter</a></li>
                     </ul>
                 </div>
-                <div class="col-md-8">
+                <div class="col-md-6">
                     <ul class="nav footer-text text-right">
                         <li>
                             <p>Copyright Verizon Media. All rights reserved.</p>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,4 +1,4 @@
-<!-- # Copyright 2019 Oath Inc. All rights reserved. -->
+<!-- # Copyright Verizon Media. All rights reserved. -->
 <nav class="navbar navbar-default navbar-fixed-top">
     <div class="container-fluid">
         <div class="navbar-header">
@@ -8,17 +8,16 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="{{ site.baseurl }}">
+            <a class="navbar-brand" href="{{ site.baseurl }}/">
                 <img alt="Vespa Logo" src="{{ site.baseurl }}/img/vespa-logo.png" width="100" height="28">
             </a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
-	        <li><a href="http://blog.vespa.ai/">Blog</a>
-                <li><a href="https://twitter.com/vespaengine">Twitter</a>
-                <li><a href="https://docs.vespa.ai">Docs</a>
-                <li><a href="https://github.com/vespa-engine" target="_blank">GitHub</a>
-                <li><a href="https://github.com/vespa-engine/vespa/issues" target="_blank">Issues</a>
+                <li><a href="{{ site.baseurl }}/getting-started">Getting Started</a>
+                <li><a href="{{ site.baseurl }}/guides">Guides</a>
+                <li><a href="{{ site.baseurl }}/support">Support</a>
+                <li><a href="http://blog.vespa.ai/">Blog</a>
             </ul>
             <div class="col-sm-offset-2 col-md-offset-2">  
                 <div class="row">

--- a/_layouts/page-wide.html
+++ b/_layouts/page-wide.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- # Copyright 2019 Oath Inc. All rights reserved. -->
+<!-- # Verizon Media. All rights reserved. -->
 <html lang="en">
 
 <head>

--- a/getting-started.html
+++ b/getting-started.html
@@ -1,0 +1,75 @@
+---
+# Copyright Verizon Media. All rights reserved.
+layout: page-wide
+---
+
+<p class="intro">
+Getting Started
+</p>
+
+<!-- ToDo: layout -->
+
+<section>
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-12">
+        <p>
+          See <a href="https://docs.vespa.ai/documentation/getting-started.html#troubleshooting">troubleshooting</a>
+          for FAQ and help.
+        </p>
+
+
+
+        <h2 id="getting-started">Getting Started</h2>
+        <p>
+          To deploy a test application,
+          run the <a href="/getting-started">Getting Started</a> guide.
+        </p>
+        <p>
+          To deploy a test application with custom Java plugin code,
+          run the <a href="/getting-started-custom-code">Getting Started Custom Code</a> guide.
+        </p>
+        <p>
+          To set up a fully functional production application,
+          see <a href="/getting-to-production">Getting to Production</a>
+        </p>
+
+
+
+        <h2 id="tutorials-and-use-cases">Tutorials and use cases</h2>
+        <p>
+          Run the tutorials to learn how Vespa can be used in search and recommender applications:
+        <ul>
+          <li><a href="https://docs.vespa.ai/documentation/tutorials/text-search.html">Text Search</a></li>
+          <li><a href="https://docs.vespa.ai/documentation/tutorials/text-search-ml.html">Improving Text Search through ML</a></li>
+          <li><a href="https://docs.vespa.ai/documentation/tutorials/text-search-semantic.html">Semantic Text Search</a></li>
+        </ul>
+        <ul>
+          <li><a href="https://docs.vespa.ai/documentation/tutorials/blog-search.html">Blog Search</a></li>
+          <li><a href="https://docs.vespa.ai/documentation/tutorials/blog-recommendation.html">Blog Recommendation</a></li>
+          <li><a href="https://docs.vespa.ai/documentation/tutorials/blog-recommendation-nn.html">Blog recommendation with Neural Network models</a></li>
+        </ul>
+        Try the <a href="https://docs.vespa.ai/documentation/use-case-shopping.html">e-commerce shopping</a> use case.
+        </p>
+
+
+
+        <h2 id="next-steps">Next Steps</h2>
+        <ul>
+          <li>
+            Follow the <a href="https://blog.vespa.ai/">Vespa Blog</a> for product updates and use cases.
+          </li><li>
+            <a href="https://docs.vespa.ai/documentation/api.html">Vespa APIs</a>
+            is useful to understand how to interface with Vespa.
+          </li><li>
+            Vespa's sample applications are found in
+            <a href="https://github.com/vespa-engine/sample-apps">sample-apps</a>.
+            Some of the guides above use these - find more info in the README files.</a>
+        </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+

--- a/guides.html
+++ b/guides.html
@@ -1,0 +1,166 @@
+---
+# Copyright Verizon Media. All rights reserved.
+layout: page-wide
+---
+
+<!-- ToDo: Move to vespa.css -->
+<style>
+  .bg-light-gray {
+    background-color: #f7f7f7;
+  }
+
+  .bg-darkest-gray {
+    background-color: #222;
+  }
+
+  .bg-white {
+    background-color: #fff;
+  }
+
+  .denali-icons {
+    color: #3F9DD8;
+  }
+
+  .subheading {
+    font-size:   2em;
+    font-weight: 700;
+  }
+</style>
+
+
+<p class="intro">
+Guides
+</p>
+
+
+<!-- https://denali-design.github.io/denali-icon-font/docs/ for font used as icons below -->
+
+<section id="automated-deployments" class="bg-light-blue">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-2 text-center">
+        <span class="d-icon is-large denali-icons d-data-storage-check"/>
+      </div>
+      <div class="col-lg-10">
+        <p class="subheading">
+          Automated Deployments
+        </p><p>
+          Learn how to automate deployments to Vespa Cloud.
+          <a href="/automated-deployments">Read more</a>.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="monitoring" class="bg-light-gray">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-2 text-center">
+        <span class="d-icon is-large denali-icons d-heart-health"/>
+      </div>
+      <div class="col-lg-10">
+        <p class="subheading">
+          Monitoring
+        </p><p>
+          Learn how to monitor Vespa Cloud applications.
+          <a href="/montoring">Read more</a>.
+      </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="security" class="bg-white">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-2 text-center">
+        <span class="d-icon is-large denali-icons d-security-verified"/>
+      </div>
+      <div class="col-lg-10">
+        <p class="subheading">
+          Security
+        </p><p>
+          Learn how to Vespa Cloud applications are secured.
+          <a href="/security-model">Read more</a>.
+      </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="benchmarking" class="bg-light-blue">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-2 text-center">
+        <span class="d-icon is-large denali-icons d-dashboard-add"/>
+      </div>
+      <div class="col-lg-10">
+        <p class="subheading">
+          Benchmarking
+        </p><p>
+          Learn how to benchmark Vespa Cloud applications.
+          <a href="/benchmarking">Read more</a>.
+      </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="data-dump" class="bg-light-gray">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-2 text-center">
+        <span class="d-icon is-large denali-icons d-cloud-download"/>
+      </div>
+      <div class="col-lg-10">
+        <p class="subheading">
+          Data Dump / Purge
+        </p><p>
+          Learn how to dump data from Vespa Cloud applications.
+          <a href="/data-dump">Read more</a>.
+      </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="testing" class="bg-white">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-2 text-center">
+        <span class="d-icon is-large denali-icons d-list-check"/>
+      </div>
+      <div class="col-lg-10">
+        <p class="subheading">
+          Testing
+        </p><p>
+          Learn how to auto test Vespa Cloud applications.
+          <a href="/testing">Read more</a>.
+      </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="model-serving" class="bg-light-blue">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-2 text-center">
+        <span class="d-icon is-large denali-icons d-machine-learning"/>
+      </div>
+      <div class="col-lg-10">
+        <p class="subheading">
+          Model serving
+        </p><p>
+        <a href="/model-serving">Read more</a>. <!-- ToDo: more text -->
+      </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section/>
+
+
+

--- a/reference-documentation.html
+++ b/reference-documentation.html
@@ -1,0 +1,85 @@
+---
+# Copyright Verizon Media. All rights reserved.
+layout: page-wide
+---
+
+<!-- ToDo: Move to vespa.css -->
+<style>
+  .bg-light-gray {
+    background-color: #f7f7f7;
+  }
+
+  .bg-darkest-gray {
+    background-color: #222;
+  }
+
+  .bg-white {
+    background-color: #fff;
+  }
+
+  .denali-icons {
+    color: #3F9DD8;
+  }
+
+  .subheading {
+    font-size:   2em;
+    font-weight: 700;
+  }
+</style>
+
+
+<p class="intro">
+Reference Documentation
+</p>
+
+
+<!-- https://denali-design.github.io/denali-icon-font/docs/ for font used as icons below -->
+
+<!-- ToDo: Add context here so readers understand the distinction ai/cloud -->
+
+<section id="vespa-cloud-reference-documentation" class="bg-light-blue">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-2 text-center">
+        <span class="d-icon is-large denali-icons d-file-multiple"/>
+      </div>
+      <div class="col-lg-10">
+        <p class="subheading">
+          Vespa Cloud Reference Documentation
+        </p><ul>
+          <li><a href="/reference/environments">Environments</a></li>
+          <li><a href="/reference/zones">Zones</a></li>
+          <li><a href="/reference/services">services.xml</a></li>
+          <li><a href="/reference/deployment">deployment.xml</a></li>
+        <!-- ToDo:
+        reference/testing.html
+        reference/vespa-cloud-api.html
+        -->
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="vespa-ai-reference-documentation" class="bg-light-blue">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-2 text-center">
+        <span class="d-icon is-large denali-icons d-file-multiple"/>
+      </div>
+      <div class="col-lg-10">
+        <p class="subheading">
+          Vespa AI Reference Documentation
+        </p><p>
+          <a href="https://docs.vespa.ai/">Reference Documentation</a>
+      </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<section/>
+
+
+

--- a/use-cases.md
+++ b/use-cases.md
@@ -1,10 +1,16 @@
 ---
-# Copyright 2019 Oath Inc. All rights reserved.
+# Copyright Verizon Media. All rights reserved.
 title: "Vespa Use Cases"
 ---
 
+<!-- ToDo: Fix page layout -->
+
 Vespa is a generic platform for Big Data Serving.
-Find sample use cases below for popular uses cases for Vespa
+Find sample use cases below for popular uses cases for Vespa.
+Also see:
+* [operational use cases](ops-use-cases)
+* [performance use cases](performance-use-cases)
+<!-- ToDo: integrate the above use cases better / rewrite -->
 
 
 


### PR DESCRIPTION
with this, all resources linked from current left frame is now reachable (in)directly from header/footer

lots of todo's, but content is not worse than before - but we can now decide to switch to new index page without the left frame in later PR