### PR TITLE
group items in left nav

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -1,14 +1,33 @@
 # Copyright Verizon Media. All rights reserved.
 docs:
-    - page: services.xml
-      url: /reference/services
-    - page: deployment.xml
-      url: /reference/deployment
-    - page: Zones
-      url: /reference/zones
-    - page: Environments
-      url: /reference/environments
-    - page: Testing
-      url: /reference/testing
-    - page: Vespa Cloud API
-      url: /reference/vespa-cloud-api
+  - title: GUIDES
+    documents:
+      - page: Automated Deployments
+        url: /automated-deployments
+      - page: Monitoring
+        url: /monitoring
+      - page: Security
+        url: /security-model
+      - page: Benchmarking
+        url: /benchmarking
+      - page: Data Dump
+        url: /data-dump
+      - page: Testing
+        url: /reference/testing
+      - page: Model Serving
+        url: /model-serving
+
+  - title: REFERENCE
+    documents:
+      - page: services.xml
+        url: /reference/services
+      - page: deployment.xml
+        url: /reference/deployment
+      - page: Zones
+        url: /reference/zones
+      - page: Environments
+        url: /reference/environments
+      - page: Testing
+        url: /reference/testing
+      - page: Vespa Cloud API
+        url: /reference/vespa-cloud-api

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,27 +2,24 @@
 
 <div class="col-sm-3 col-md-2 sidebar">
 	{% if site.data.sidebar.docs[0] %}
-		<ul class="nav nav-sidebar">
-		{% for entry in site.data.sidebar.docs %}
-			{% if entry.url == page.url %}
-				<li class="active"><a href="{{ entry.url }}">{{ entry.page }} <span class="sr-only">(current)</span></a></li>
-			{% else %}
-				<li><a href="{{ entry.url }}">{{ entry.page }}</a></li>
-			{% endif %}
-			{% if entry.subdocuments[0] %}
-				<div class="subdocuments">
-					<ul class="nav nav-sidebar">
-						{% for subentry in entry.subdocuments %}
-							{% if subentry.url == page.url %}
-								<li class="active"><a href="{{ subentry.url }}">{{ subentry.page }} <span class="sr-only">(current)</span></a></li>
-							{% else %}
-								<li><a href="{{ subentry.url }}">{{ subentry.page }}</a></li>
-							{% endif %}
-						{% endfor %}
-					</ul>
-				</div>
-			{% endif %}
+		{% for item in site.data.sidebar.docs %}
+			<ul class="nav nav-sidebar">
+				<li >{{ item.title }}</li>
+				{% if item.documents[0] %}
+					{% for entry in item.documents %}
+							<li ><a href="{{ entry.url }}">{{ entry.page }}</a></li>
+						{% if entry.subdocuments[0] %}
+							<div class="subdocuments collapseable">
+								<ul class="nav nav-sidebar">
+									{% for subentry in entry.subdocuments %}
+											<li><a href="{{ subentry.url }}">{{ subentry.page }}</a></li>
+									{% endfor %}
+								</ul>
+							</div>
+						{% endif %}
+					{% endfor %}
+				{% endif %}
+			</ul>
 		{% endfor %}
-		</ul>
 	{% endif %}
 </div>


### PR DESCRIPTION
This is a suggestion - not sure if keep or not. Assuming we want to have a left bar for "documentation" articles like guides and references, this will work. Copied from vespa doc repo, but skipped the collapse logic for now, can add if we need to

note that there is some overlap in guide and ref doc, like the testing doc. not sure what is right. resolve later
