### PR TITLE
Somewhat better copy and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,86 +12,94 @@ layout: page-wide
 
 <!-- https://denali-design.github.io/denali-icon-font/docs/ for font used as icons below -->
 
-
 <div class="container">
   <div class="row">
-    <div class="col">
+    <div class="col-lg-2 col-xl-2"></div>
+
+    <div class="col-lg-10 col-xl-10">
       <h1 class="intro">Vespa Cloud<br/>
-        <span style="font-size: 18pt">The cheapest, fastest and best way to run your Vespa applications.</span></h1>
+        <span style="font-size: 18pt">The easiest, safest and most cost effective way to run your Vespa applications.</span></h1>
     </div>
   </div>
 </div>
 
 <div class="container">
   <div class="row">
-    <div class="col">
-      <p>By deploying  your applications to Vespa Cloud you get:</p>
+
+    <div class="col-lg-2 col-xl-2"></div>
+
+    <div class="col-lg-8 col-xl-8">
+      <p>
+        Whether you just need to quickly deploy some experiments, or run an
+        always available world-wide production system handling thousand of requests per second,
+        the Vespa Cloud will fit your needs. What you get:
+      </p>
       <table class="table table-striped">
         <tr>
           <td><span class="d-icon is-small denali-icon-color d-chart-line-time"></span></td>
           <td >
-            <strong>Proactive, automated world-class 24x7 operations:</strong>
-            Focus your team on innovation, not operations.
+            <strong><a href="#operations">World-class 24x7 operations</a>:</strong>
+            We'll keep your system running so you can focus on innovation.
           </td>
         </tr>
         <tr>
           <td><span class="d-icon is-small denali-icon-color d-handshake"></span></td>
           <td>
-            <strong>Support:</strong>
+            <strong><a href="#support">Support</a>:</strong>
             Next-day support from the Vespa experts included.
           </td>
         </tr>
         <tr>
           <td><span class="d-icon is-small denali-icon-color d-data-storage-check"></span></td>
           <td>
-            <strong>Continuous deployment:</strong>
+            <strong><a href="#continuous-deployment">Continuous deployment</a>:</strong>
             Immediate, automatic and safe deployments of application changes.</td>
         </tr>
         <tr>
           <td><span class="d-icon is-small denali-icon-color d-swap-horizontal-circle"></span></td>
           <td>
-            <strong>Automated Vespa/OS upgrades:</strong>
-            Receive features, bug fixes, and performance improvements daily. No effort required.
+            <strong><a href="#upgrades">Automatic Vespa/OS upgrades</a>:</strong>
+            Get features, fixes, and performance improvements daily. No effort required.
           </td>
         </tr>
         <tr>
           <td><span class="d-icon is-small denali-icon-color d-security-verified"></span></td>
           <td>
-            <strong>Strong security:</strong>
+            <strong><a href="#security">Strong security</a>:</strong>
             Hardened OS and VM. All communication over mTLS with per-node certificates.
           </td>
         </tr>
         <tr>
           <td><span class="d-icon is-small denali-icon-color d-scale-expand"></span></td>
           <td>
-            <strong>Autoscaling:</strong>
+            <strong><a href="#autoscaling">Autoscaling</a>:</strong>
             Reduce cost by letting applications scale automatically with usage.
           </td>
         </tr>
         <tr>
           <td><span class="d-icon is-small denali-icon-color d-currency-bag-dollar"></span></td>
           <td>
-            <strong>Vespa performance tune-up program eligibility:</strong>
+            <strong><a href="#performance">Vespa performance tune-up program eligibility</a>:</strong>
             Typically reduces cost by about 50%.
           </td>
         </tr>
         <tr>
           <td><span class="d-icon is-small denali-icon-color d-tools"></span></td>
           <td>
-            <strong>Development Cloud:</strong>
+            <strong><a href="#development">Development Cloud</a>:</strong>
             Let developers experiment with their own copies of applications in seconds.
           </td>
         </tr>
       </table>
     </div>
   </div>
+
   <div class="row">
-    <div class="col text-center">
-      <p>
-        <a target="_blank" class="btn btn-primary btn-lg intro-button"
-           href="https://console.vespa.ai">Start your free trial</a>
-      </p>
-    <div class="col text-center">
+    <div class="col-lg-2 col-xl-2"></div>
+    <div class="col-lg-2 col-xl-2 text-center">
+      <a target="_blank" class="btn btn-primary btn-lg intro-button" href="https://console.vespa.ai">Start your free trial</a>
+    </div>
+    <div class="col-lg-6 col-xl-6">
       <p>
         You'll need a Google or GitHub identity. Once registered you can add more users from your org.
         If already registered, clicking will <a href="https://console.vespa.ai">sign you back in</a>.
@@ -103,68 +111,13 @@ layout: page-wide
 <section id="whitespace">
 </section>
 
-<section id="model-serving" class="bg-light-blue">
-  <div class="container">
-    <div class="row m-50">
-      <div class="col-lg-2 text-center">
-        <span class="d-icon is-large denali-icon-color d-machine-learning"></span>
-      </div>
-      <div class="col-lg-10">
-        <h2>Model Serving</h2>
-        <p>
-          The best teams do not only train models, but build a system with signals to model training,
-          model training automation, automated model deployment and live model updates.
-          This keeps the model current, and routine tasks are automated -
-          all work can go into improving the model.
-        </p>
-        <p>
-          Vespa Cloud’s role is being a component in this cycle,
-          see <a href="model-serving">model serving</a>.
-          Emit data for next model training cycle using grid logging and feature export.
-          Then accept a new model version using Safe Launches by just deploying a new model URL. Repeat.
-        </p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section id="leading-edge" class="bg-white">
-  <div class="container">
-    <div class="row">
-      <div class="col-lg-2 text-center">
-        <span class="d-icon is-large denali-icon-color d-chart-metric"></span>
-      </div>
-      <div class="col-lg-10">
-        <h2>Leading Edge</h2>
-        <p>
-          The best teams are global leaders in their business, or working to be.
-          They drive Vespa to implement new features, so teams can innovate together.
-          Vespa Cloud lets teams access features as they are built.
-          Lead time from feature request to ready-to-use is at best days - but can be years,
-          for game-changing features like <a
-                href="https://docs.vespa.ai/documentation/tensor-user-guide.html">tensors</a>
-          and <a href="https://docs.vespa.ai/documentation/reference/query-language-reference.html">approximate
-          nearest-neighbor</a>.
-        </p>
-        <p>
-          Organizations use Vespa to get a competitive advantage,
-          and <a href="https://vespa.ai/">Vespa.ai</a> enables that.
-          They use Vespa Cloud to let teams use their expertise best,
-          and work closely with Vespa Experts to use the right features the right ways.
-          Follow the <a href="https://blog.vespa.ai/">Vespa Blog</a> for the latest news.
-        </p>
-      </div>
-    </div>
-  </div>
-</section>
-
 <section id="cost-optimization-in-place-upgrades" class="bg-light-blue">
   <div class="container">
     <div class="row">
-      <div class="col-lg-2 text-center">
+      <div class="col-lg-2 col-xl-2 text-center">
         <span class="d-icon is-large denali-icon-color d-swap-horizontal-circle"></span>
       </div>
-      <div class="col-lg-10">
+      <div class="col-lg-10 col-xl-10">
         <h2>Cost Optimization: In-place Upgrades</h2>
         <p>
           Vespa is built to be always-on, also while upgrading.
@@ -196,10 +149,10 @@ layout: page-wide
 <section id="cost-optimization-simple-pricing-model" class="bg-white">
   <div class="container">
     <div class="row">
-      <div class="col-lg-2 text-center">
+      <div class="col-lg-2 col-xl-2 text-center">
         <span class="d-icon is-large denali-icon-color d-currency-bag-dollar"></span>
       </div>
-      <div class="col-lg-10 text-left">
+      <div class="col-lg-10 col-xl-10 text-left">
         <h2>Cost Optimization: Simple Pricing Model</h2>
         <p>
           Transparent and easy-to-understand <a href="pricing">pricing model</a>,
@@ -230,10 +183,10 @@ layout: page-wide
 <section id="developer-cloud" class="bg-light-gray">
   <div class="container">
     <div class="row">
-      <div class="col-lg-2 text-center">
+      <div class="col-lg-2 col-xl-2 text-center">
         <span class="d-icon is-large denali-icon-color d-tools"></span>
       </div>
-      <div class="col-lg-10">
+      <div class="col-lg-10 col-xl-10">
         <h2>Developer Cloud</h2>
         <p>
           Using the Vespa Cloud Sandbox and <a href="https://github.com/vespa-engine/sample-apps/blob/master/README.md">sample
@@ -256,10 +209,10 @@ layout: page-wide
 <section id="performance-cloud" class="bg-light-blue">
   <div class="container">
     <div class="row">
-      <div class="col-lg-2 text-center">
-        <span class="d-icon is-large denali-icon-color d-dashboard-add></span>
+      <div class="col-lg-2 col-xl-2 text-center">
+        <span class="d-icon is-large denali-icon-color d-dashboard-add"></span>
       </div>
-      <div class="col-lg-10 text-left">
+      <div class="col-lg-10 col-xl-10 text-left">
         <h2>Performance Cloud</h2>
         <p>
           Vespa applications range from applications with 100k documents and 100k query load,
@@ -287,10 +240,10 @@ layout: page-wide
 <section id="safe-launches" class="bg-white">
   <div class="container">
     <div class="row">
-      <div class="col-lg-2 text-center">
+      <div class="col-lg-2 col-xl-2 text-center">
         <span class="d-icon is-large denali-icon-color d-data-storage-check"></span>
       </div>
-      <div class="col-lg-10 text-left">
+      <div class="col-lg-10 col-xl-10 text-left">
         <h2>Safe Launches</h2>
         <p>
           The best launches are non-events.
@@ -322,13 +275,14 @@ layout: page-wide
   </div>
 </section>
 
+
 <section id="quality" class="bg-light-gray">
   <div class="container">
     <div class="row">
-      <div class="col-lg-2 text-center">
+      <div class="col-lg-2 col-xl-2 text-center">
         <span class="d-icon is-large denali-icon-color d-bug"></span>
       </div>
-      <div class="col-lg-10">
+      <div class="col-lg-10 col-xl-10">
         <h2>Quality</h2>
         <p>
           Bugs happen, and quick failure resolution is essential.
@@ -356,10 +310,10 @@ layout: page-wide
 <section id="data-privacy" class="bg-light-blue">
   <div class="container">
     <div class="row">
-      <div class="col-lg-2 text-center">
+      <div class="col-lg-2 col-xl-2 text-center">
         <span class="d-icon is-large denali-icon-color d-user-canonical"></span>
       </div>
-      <div class="col-lg-10 text-left">
+      <div class="col-lg-10 col-xl-10 text-left">
         <h2>Data Privacy</h2>
         <p>
           The General Data Protection Regulation (GDPR) and California Consumer Privacy Act (CCPA)
@@ -382,10 +336,10 @@ layout: page-wide
 <section id="security" class="bg-white">
   <div class="container">
     <div class="row">
-      <div class="col-lg-2 text-center">
+      <div class="col-lg-2 col-xl-2 text-center">
         <span class="d-icon is-large denali-icon-color d-security-verified"></span>
       </div>
-      <div class="col-lg-10">
+      <div class="col-lg-10 col-xl-10">
         <h2>Security</h2>
         <p>
           Using the Auto in-place Upgrader (above), Vespa code and dependencies are upgraded multiple times a week.


### PR DESCRIPTION
@kkraune or @frodelu 

It's about time we switch to denali cause I've found a subset of bootstrap which predictably does what it says it should

I think the text in the first table and above is ok now (but layout should be changed a lot).

I want each of the table rows (i.e Vespa cloud "features") to point into the next sections of the document, and I'll work on that next. I removed the sections that didn't map to any of them (since they were more about Vespa than the cloud).