### PR TITLE
Show latest status messages first

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,6 @@ gem "github-pages"
 # Get the html-proofer to work
 gem 'rake'
 gem 'html-proofer'
+
+# Work-around for webrick no longer included in Ruby 3.0 (https://github.com/jekyll/jekyll/issues/8523)
+gem "webrick"

--- a/status.html
+++ b/status.html
@@ -35,8 +35,9 @@ title: Status
             <h3>Messages</h3>
             {% if site.data.status.messages[0] %}
             {% assign datelimit = "now" | date: '%s' | minus:604800 %}
+            {% assign sorted_messages = site.data.status.messages | sort: 'date' | reverse %}
             <table class="table" style="width: 90%; margin-left: auto; margin-right: auto;">
-            {% for message in site.data.status.messages %}
+            {% for message in sorted_messages %}
                 {% assign epoch = message.date | date: '%s' | ceil %}
                 {% if epoch >= datelimit %}
                 <tr>

--- a/status.html
+++ b/status.html
@@ -34,7 +34,7 @@ title: Status
 
             <h3>Messages</h3>
             {% if site.data.status.messages[0] %}
-            {% assign datelimit = "now" | date: '%s' | minus:604800 %}
+            {% assign datelimit = 'now' | date: '%s' | minus:604800 %}
             {% assign sorted_messages = site.data.status.messages | sort: 'date' | reverse %}
             <table class="table" style="width: 90%; margin-left: auto; margin-right: auto;">
             {% for message in sorted_messages %}

--- a/status.json
+++ b/status.json
@@ -3,6 +3,9 @@ layout: status
 # Data for this page is found in _data/status.yml
 ---
 {
-	"last-updated": "{{ "now" | date: "%s" }}",
-	"status": {{ site.data.status | jsonify }}
+    "last-updated": "{{ "now" | date: "%s" }}",
+    "status": {
+        "zones": {{ site.data.status.zones | jsonify }},
+        "messages": {{ site.data.status.messages | sort: 'date' | reverse | jsonify }}
+    }
 }

--- a/status.json
+++ b/status.json
@@ -3,7 +3,7 @@ layout: status
 # Data for this page is found in _data/status.yml
 ---
 {
-    "last-updated": "{{ "now" | date: "%s" }}",
+    "last-updated": "{{ 'now' | date: '%s' }}",
     "status": {
         "zones": {{ site.data.status.zones | jsonify }},
         "messages": {{ site.data.status.messages | sort: 'date' | reverse | jsonify }}


### PR DESCRIPTION
Makes more sense to have most recent status messages show up on top. @smorgrav, please confirm this won't impact the console's use of `status.json`. 

FYI @kkraune and @oyving 