### PR TITLE
Fix background colors for responsive menu on light pages

### DIFF
--- a/css/denali-theme-vespa-light.scss
+++ b/css/denali-theme-vespa-light.scss
@@ -263,8 +263,8 @@ $navbar-item-text-color: $color-brand-400;
 $navbar-item-hover-text-color: rgba($color-brand-400, 0.4);
 $navbar-item-active-text-color: $color-brand-300;
 $navbar-item-active-border-color: #ff9750;
-$navbar-responsive-bg-color: $color-brand-400;
-$navbar-responsive-menu-bg-color: $color-brand-300;
+$navbar-responsive-bg-color: #ffffff;
+$navbar-responsive-menu-bg-color: $color-grey-400;
 
 // Progress
 $progress-bg-color: $color-grey-400;


### PR DESCRIPTION
@kkraune / @bratseth : This should fix the menu on mobile devices