### PR TITLE
create /support resource

### DIFF
--- a/support.html
+++ b/support.html
@@ -1,0 +1,26 @@
+---
+# Copyright Verizon Media. All rights reserved.
+title: Vespa Cloud Support
+layout: page
+---
+
+<table>
+  <tr>
+    <td style="width: 125px;"><a href="/status">Operational status</a></td>
+    <td><em>Up to date status information on all zones.</em></td>
+  </tr>
+  <tr>
+    <td>&nbsp;</td>
+  </tr>
+  <tr>
+    <td><a href="mailto:support@vespa.ai">Request support</a></td>
+    <td><em>Create a support ticket.</em></td>
+  </tr>
+  <tr>
+    <td>&nbsp;</td>
+  </tr>
+  <tr>
+    <td><a href="https://vespa.ai/support">Vespa.ai support</a></td>
+    <td><em>Resources for using and troubleshooting Vespa. Access the community.</em></td>
+  </tr>
+</table>


### PR DESCRIPTION
The console refers to support, so we should have cloud.vespa.ai/support. This is the minimal to fix broken console links. 

This is also useful in other settings, when communicating over slack/email - "please use cloud.vespa.ai/support" ...

lets refine the looks in later PR @bratseth @frodelu 

@freva once merged, please check console