### PR TITLE
Redirect for legacy links that are used in console and vespa

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,9 +1,0 @@
-<!-- # Copyright Verizon Media. All rights reserved. -->
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to {{page.redirect_target}}</title>
-<meta http-equiv="refresh" content="0; URL={{page.redirect_target}}">
-<link rel="canonical" href="{{page.redirect_target}}">
-<body>
-<p>Redirecting you to <a href="{{page.redirect_target}}">{{page.redirect_target}}</a> - click link if not redirected automatically.</p>
-</body>

--- a/en/automated-deployments.html
+++ b/en/automated-deployments.html
@@ -2,6 +2,7 @@
 # Copyright Verizon Media. All rights reserved.
 title: Automated Deployments
 layout: page
+redirect_from: /automated-deployments.html
 ---
 
 

--- a/en/developer-guide.html
+++ b/en/developer-guide.html
@@ -2,6 +2,7 @@
 # Copyright Verizon Media. All rights reserved.
 title: Developer Guide
 layout: page
+redirect_from: /developer-guide.html
 ---
 
 <p>

--- a/en/getting-started.html
+++ b/en/getting-started.html
@@ -2,6 +2,7 @@
 # Copyright Verizon Media. All rights reserved.
 title: Getting Started with the Vespa Cloud
 layout: page
+redirect_from: /getting-started.html
 ---
 
 <!-- If you change this also make the same change in getting-started-java -->

--- a/en/getting-to-production.html
+++ b/en/getting-to-production.html
@@ -2,6 +2,7 @@
 # Copyright Verizon Media. All rights reserved.
 title: Getting to Production
 layout: page
+redirect_from: /getting-to-production.html
 ---
 
 <p>

--- a/en/reference/deployment.html
+++ b/en/reference/deployment.html
@@ -2,6 +2,7 @@
 # Copyright Verizon Media. All rights reserved.
 title: deployment.xml
 layout: page
+redirect_from: /reference/deployment.html
 ---
 
 <p>

--- a/en/reference/environments.html
+++ b/en/reference/environments.html
@@ -2,6 +2,7 @@
 # Copyright Verizon Media. All rights reserved.
 title: Environments
 layout: page
+redirect_from: /environments.html
 ---
 
 <p>

--- a/en/security-model.html
+++ b/en/security-model.html
@@ -2,6 +2,7 @@
 # Copyright Verizon Media. All rights reserved.
 title: Security model
 layout: page
+redirect_from: /security-model.html
 ---
 
 <p>


### PR DESCRIPTION
- Removed the redirect template as it was creating issues. The default template seems to work.
- Added `redirect_from` to the resources that are referenced in Vespa and Console.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
