### PR TITLE
Kkraune/env zone

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -49,7 +49,6 @@ layout: page
 <li><a href="reference/services">services.xml</a></li>
 <li><a href="reference/deployment">deployment.xml</a></li>
 <li><a href="reference/zones">Zones</a></li>
-<li><a href="reference/environments">Environments</a></li>
 <li><a href="reference/testing">Testing</a></li>
 <li><a href="reference/vespa-cloud-api">Vespa Cloud Api</a></li>
 </ul>

--- a/en/reference/deployment.html
+++ b/en/reference/deployment.html
@@ -169,7 +169,8 @@ in the PT time zone:</p>
 <table class="table">
   <tr>
   <td><code>&lt;deployment&gt;</code> <code>&lt;instance&gt;</code></td>
-  <td>If present, the application is deployed to the <a href="environments.html#test"><code>test</code></a> environment,
+  <td>If present, the application is deployed to the
+    <a href="zones#test-and-staging-environments"><code>test</code></a> environment,
     and system tested there, even if no prod zones are deployed to.
     If present in an <code>&lt;instance&gt;</code> element, system tests are run for that specific instance before any
     production deployments of the instance may proceed — otherwise, previous system tests for any instance are acceptable.</td>
@@ -187,7 +188,8 @@ in the PT time zone:</p>
 
 <p>
 In <code>&lt;deployment&gt;</code>, or <code>&lt;instance&gt;</code>.
-If present, the application is deployed to the <a href="environments.html#staging"><code>staging</code></a> environment,
+If present, the application is deployed to the
+<a href="zones#test-and-staging-environments"><code>staging</code></a> environment,
 and tested there, even if no prod zones are deployed to.
 If present in an <code>&lt;instance&gt;</code> element, staging tests are run for that specific instance before any
 production deployments of the instance may proceed — otherwise, previous staging tests for any instance are acceptable.

--- a/en/reference/services.html
+++ b/en/reference/services.html
@@ -249,7 +249,7 @@ Whereas in <em>prod.us-west-1</em> it is:
     is used together with the element name when applying directives.</li>
 </ul>
 
-<p>Some overrides are applied by default in some environments, see <a href="environments">environments</a>.
+<p>Some overrides are applied by default in some environments, see <a href="zones">environments</a>.
 Any override made explicitly for an environment will override the defaults for it.</p>
 
 

--- a/en/reference/testing.html
+++ b/en/reference/testing.html
@@ -113,8 +113,9 @@ This runs a system test against an instance in the <em>dev</em> environment on V
 
 <p>
 The default behavior of <code>mvn package vespa:deploy</code> is to deploy to the
-<a href="environments#dev">dev</a> environment,
-and the default behavior of <code>mvn test -Dtest.categories=system</code> is to run system tests against this dev deployment.
+<a href="zones#dev-and-perf-environments">dev</a> environment,
+and the default behavior of <code>mvn test -Dtest.categories=system</code>
+is to run system tests against this dev deployment.
 The <em>tenant</em> and <em>application</em> properties (can be set in <em>pom.xml</em>),
 together with the <em>instance</em> property which defaults to the current user's username,
 determines the deployment to create or test.
@@ -126,7 +127,7 @@ determines the deployment to create or test.
 
 <p>
 During <a href="../automated-deployments">automated tests</a>,
-a fresh deployment is made to the <a href="environments#test">test environment</a>.
+a fresh deployment is made to the <a href="zones#test-and-staging-environments">test environment</a>.
 When tests are run, the endpoints from the test deployment are used.
 The test deployment is empty when the test execution begins,
 documents must be fed as part of the system test.
@@ -192,7 +193,8 @@ The staging test then consists of the following steps:
 </p>
 
 <ol class="howto">
-  <li>Deploy the initial pair <code>X, Y</code> to the <a href="environments#staging">staging environment</a>.</li>
+  <li>Deploy the initial pair <code>X, Y</code> to the
+    <a href="zones#test-and-staging-environments">staging environment</a>.</li>
   <li>Populate the deployment with data, making it reasonably similar to a production deployment.
       This is done by the <code>@StagingSetup</code>-annotated code, which typically feeds a set of static documents.</li>
   <li>Upgrade the deployment to the target pair <code>X+1, Y+1</code>.</li>

--- a/en/reference/vespa-cloud-api.html
+++ b/en/reference/vespa-cloud-api.html
@@ -234,7 +234,7 @@ when running system or staging tests with <code>mvn test</code> or in an IDE.
   <tr>
     <td>environment</td>
     <td>No; defaults to <code>dev</code></td>
-    <td>The <a href="environments">environment</a> to deploy to, delete from, or run tests against.</td>
+    <td>The <a href="zones">environment</a> to deploy to, delete from, or run tests against.</td>
   </tr>
   <tr>
     <td>region</td>

--- a/en/reference/zones.html
+++ b/en/reference/zones.html
@@ -1,41 +1,151 @@
 ---
 # Copyright Verizon Media. All rights reserved.
-title: Zones
+title: "Zones: environments and regions"
 layout: page
 ---
 
+<!-- ToDo: move to style sheet later -->
+<style>
+    td { vertical-align: top; }
+</style>
+
+
 <p>
-An application can be deployed to a <em>zone</em>,
-which is a combination of an <a href="environments">environment</a>
-and a <em>region</em>.
-This lists all the zones which can be deployed to manually (dev and perf),
-deployed to in production using <a href="deployment">deployment.xml</a> (prod),
-or which is <a href="../automated-deployments">implicitly used to verify prod deployments</a>
-(test and staging):
+An application can be deployed to one or more <em>zones</em>,
+which is a combination of an <em>environment</em> and a <em>region</em>.
 </p>
-<table class="table table-striped">
+
+<table class="table">
   <thead>
-    <tr><th style="width:80px">Environment</th><th>Region</th></tr>
+  <tr><th>Name</th><th>Expiry</th><th>Cluster sizes</th><th>Regions</th></tr>
   </thead>
   <tbody>
-    <tr><td><a href="environments#dev">dev</a>        <td>aws-us-east-1c</tr>
-    <tr><td><a href="environments#perf">perf</a>      <td>aws-us-east-1c</tr>
-    <tr><td><a href="environments#test">test</a>      <td>aws-us-east-1c</tr>
-    <tr><td><a href="environments#staging">staging</a><td>aws-us-east-1c</tr>
-    <tr><td><a href="environments#prod">prod</a>      <td>aws-us-east-1c</tr>
-    <tr><td><a href="environments#prod">prod</a>      <td>aws-us-west-2a</tr>
-    <tr><td><a href="environments#prod">prod</a>      <td>aws-eu-west-1a</tr>
-    <tr><td><a href="environments#prod">prod</a>      <td>aws-ap-northeast-1a</tr>
+  <tr>
+    <td id="dev">dev</td>
+    <td>7 days</td> <!-- https://git.vzbuilders.com/vespa/vespa-yahoo/blob/master/hosted/zone-specification/src/main/java/com/yahoo/vespa/hosted/spec/Zones.java#L1291 -->
+    <td>1</td>
+    <td>
+      <table class="table">
+        <tbody>
+        <tr><td>aws-us-east-1c</td></tr>
+        </tbody>
+      </table>
+    </td>
+  </tr><tr>
+    <td id="perf">perf</td>
+    <td>7 days</td>
+    <td>min(3, spec)</td>
+    <td>
+      <table class="table">
+        <tbody>
+        <tr><td>aws-us-east-1c</td></tr>
+        </tbody>
+      </table>
+    </td>
+  </tr><tr>
+    <td id="test">test</td>
+    <td>2 hours</td>
+    <td>1</td>
+    <td>
+      <table class="table">
+        <tbody>
+        <tr><td>aws-us-east-1c</td></tr>
+        </tbody>
+      </table>
+    </td>
+  </tr><tr>
+    <td id="staging">staging</td>
+    <td>6 hours</td>
+    <td>min(max(2, 0.1 * spec), spec)</td>
+    <td>
+      <table class="table">
+        <tbody>
+        <tr><td>aws-us-east-1c</td></tr>
+        </tbody>
+      </table>
+    </td>
+  </tr><tr>
+    <td id="prod">prod</td>
+    <td>No expiry</td>
+    <td>max(2, spec)</td>
+    <td>
+      <table class="table">
+        <tbody>
+          <tr><td>aws-us-east-1c</td></tr>
+          <tr><td>aws-us-west-2a</td></tr>
+          <tr><td>aws-eu-west-1a</td></tr>
+          <tr><td>aws-ap-northeast-1a</td></tr>
+        </tbody>
+      </table>
+    </td>
+  </tr>
   </tbody>
 </table>
-
-<p>If your deployment requires zones not listed here, contact us to have it made available.</p>
-
 <p>
-If the application application requires zone-specific configuration,
-use <a href="services#instance-environment-and-region-variants">
-environment and region variants</a>.
+  If your deployment requires zones not listed here, contact the Vespa Team to have it made available.
 </p>
+<p>
+  If the application requires instance/zone-specific configuration,
+  use <a href="services#instance-environment-and-region-variants">
+  environment and region variants</a>.
+</p>
+
+
+
+<h2 id="dev-and-perf-environments">Dev and Perf environments</h2>
+<p>
+  Instances in <em>dev</em> and <em>perf</em> environments are deployed to manually,
+  used for manual development/performance testing.
+</p>
+<p>
+  In order to easily deploy application packages from prod applications,
+  resources are downscaled in <em>dev</em> and <em>perf</em>.
+  To control the resources you get in these zones,
+  specify them explicitly for the environment in question (<em>dev</em> or <em>perf</em>) as described in
+  <a href="services#instance-environment-and-region-variants">environment and region variants</a>.
+</p>
+<p>
+  The <em>dev</em> environment is default, to deploy to the <em>perf</em> environment, use:
+</p>
+<pre>
+$ mvn package vespa:deploy -Denvironment=perf
+</pre>
+
+
+
+<h2 id="test-and-staging-environments">Test and staging environments</h2>
+<p>
+  Whenever an application package is submitted to <em>prod</em>,
+  instances are set up in <em>test</em> and <em>staging</em> to
+  <a href="../automated-deployments">verify prod deployments</a>.
+  See <a href="testing#system-tests">automated system tests</a> and
+  <a href="testing#staging-tests">automated staging tests</a>.
+</p>
+
+
+
+<h2 id="production-environment">Production environment</h2>
+<p>
+  Hosts all production deployments.
+  deployed to in production using <a href="deployment">deployment.xml</a> (prod),
+</p>
+<p>
+  Deployments in <em>prod</em> must have at least one more node than required to handle peak load.
+  A cluster is a <em>container</em> or <em>content</em> cluster,
+  and a regular application has a container <em>and</em> a content cluster.
+  A minimal, typical <em>prod</em> deployment therefore has 4 nodes.
+</p>
+
+
+<h2 id="vespa-version">Vespa version</h2>
+<p>
+  In <em>dev</em> and <em>perf</em>, the latest active Vespa version is used when deploying.
+  An instance is not upgraded, unless deployed to.
+  This means that some times, a deploy takes longer than normal,
+  as it invokes a Vespa upgrade before deploying the application package.
+</p>
+
+
 
 
 

--- a/en/reference/zones.html
+++ b/en/reference/zones.html
@@ -89,31 +89,89 @@ which is a combination of an <em>environment</em> and a <em>region</em>.
   use <a href="services#instance-environment-and-region-variants">
   environment and region variants</a>.
 </p>
+<p>
+  Use the <em>application</em> view in the Vespa Console to list instances in the various zones.
+</p>
 
 
 
 <h2 id="dev-and-perf-environments">Dev and Perf environments</h2>
 <p>
   Instances in <em>dev</em> and <em>perf</em> environments are deployed to manually,
-  used for manual development/performance testing.
-</p>
-<p>
-  In order to easily deploy application packages from prod applications,
-  resources are downscaled in <em>dev</em> and <em>perf</em>.
-  To control the resources you get in these zones,
-  specify them explicitly for the environment in question (<em>dev</em> or <em>perf</em>) as described in
-  <a href="services#instance-environment-and-region-variants">environment and region variants</a>.
-</p>
-<p>
+  using <a href="vespa-cloud-api">mvn vespa:deploy</a>.
+  These environments are used for manual development/performance testing.
   The <em>dev</em> environment is default, to deploy to the <em>perf</em> environment, use:
 </p>
 <pre>
 $ mvn package vespa:deploy -Denvironment=perf
 </pre>
+<p>
+  <em>dev</em> and <em>perf</em> are optimized for cost and developer friendliness/ease:
+</p>
+<ul class="howto">
+  <li>
+    In order to easily deploy application packages from prod applications,
+    resources are downscaled in <em>dev</em> and <em>perf</em> -
+    see cluster size in the table above.
+    To control the resources you get in these zones,
+    specify them explicitly for the environment in question (<em>dev</em> or <em>perf</em>) as described in
+    <a href="services#instance-environment-and-region-variants">environment and region variants</a>, e.g:
+<pre>
+&lt;nodes deploy:environment="dev" count="3"/&gt;
+</pre>
+  </li>
+  <li>
+    The latest active Vespa version is used when deploying.
+    An instance is not upgraded, unless deployed to.
+    This means that some times, a deploy takes longer than normal,
+    as it invokes a Vespa upgrade before deploying the application package.
+  </li>
+  <li>
+    Instances in these environments are expired automatically after 7 days of last deployment -
+    data is then auto deleted.
+    Make sure to deploy to the instance at least weekly to keep it alive.
+  </li>
+</ul>
+<p>
+  <strong>Important note:</strong> <em>dev</em> and <em>perf</em> environments do not have availability guarantees.
+  Also, the default redundancy in <em>dev</em> is 1 due to the node count downscaling -
+  if nodes fail / are swapped, data is lost.
+  Do not use instances in <em>dev</em> or <em>perf</em> for other purposes than manual testing.
+</p>
 
 
 
-<h2 id="test-and-staging-environments">Test and staging environments</h2>
+<h2 id="production-environment">Production environment</h2>
+<p>
+  <em>prod</em> instances are deployed to using <a href="vespa-cloud-api">mvn vespa:submit</a>.
+  Use <a href="deployment">deployment.xml</a> to configure with regions to submit to.
+  Find details in <a href="/en/automated-deployments">automated deployments</a>.
+</p>
+<p>
+  <em>prod</em> is optimized for safety, operability and production stability:
+</p>
+<ul class="howto">
+  <li>
+    Operating system and Vespa software is continuously upgraded,
+    taking down one node (or a subset) at a time.
+    This means, instances in <em>prod</em> must have at least one more node than required to handle peak load.
+  </li>
+  <li>
+    A cluster is a <em>container</em> or <em>content</em> cluster,
+    and a regular application has a container <em>and</em> a content cluster.
+    A minimal, typical <em>prod</em> deployment therefore has 4 nodes,
+    as the minimum cluster size is 2 (see table above).
+  </li>
+  <li>
+    Submissions to <em>prod</em> invoke automatic testing using ephemeral instances
+    in <em>test</em> and <em>staging</em> environments.
+    Refer to <a href="/en/automated-deployments">automated deployments</a>.
+  </li>
+</ul>
+
+
+
+<h2 id="test-and-staging-environments">Test and Staging environments</h2>
 <p>
   Whenever an application package is submitted to <em>prod</em>,
   instances are set up in <em>test</em> and <em>staging</em> to
@@ -121,31 +179,6 @@ $ mvn package vespa:deploy -Denvironment=perf
   See <a href="testing#system-tests">automated system tests</a> and
   <a href="testing#staging-tests">automated staging tests</a>.
 </p>
-
-
-
-<h2 id="production-environment">Production environment</h2>
-<p>
-  Hosts all production deployments.
-  deployed to in production using <a href="deployment">deployment.xml</a> (prod),
-</p>
-<p>
-  Deployments in <em>prod</em> must have at least one more node than required to handle peak load.
-  A cluster is a <em>container</em> or <em>content</em> cluster,
-  and a regular application has a container <em>and</em> a content cluster.
-  A minimal, typical <em>prod</em> deployment therefore has 4 nodes.
-</p>
-
-
-<h2 id="vespa-version">Vespa version</h2>
-<p>
-  In <em>dev</em> and <em>perf</em>, the latest active Vespa version is used when deploying.
-  An instance is not upgraded, unless deployed to.
-  This means that some times, a deploy takes longer than normal,
-  as it invokes a Vespa upgrade before deploying the application package.
-</p>
-
-
 
 
 

--- a/pricing.html
+++ b/pricing.html
@@ -93,7 +93,7 @@ committed resources at lower cost, or have other pricing requests.
 Resources allocated in production zones are precisely what specified in <a href="en/reference/services">services.xml</a>
 for the duration the application is deployed. If resources are specified in ranges (autoscaling)
 the resources allocated at any time is the optimal allocation inside the range.
-In dev and test zones, applications will by default be <a href="en/reference/environments">downscaled</a>,
+In dev and test zones, applications will by default be <a href="en/reference/zones">downscaled</a>,
 and charges are by the actual usage summed over time.
 </p>
 <p>


### PR DESCRIPTION
I found it clunky to keep environment and zone in different documents, easier to document in one doc. the first commit is just merging the two, no semantic changes

the second commit is clarification and some more info, hopefully easier for users to get the different properties for the different environments / zones 

@bratseth @frodelu 
