### PR TITLE
supply instance as well

### DIFF
--- a/en/reference/testing.html
+++ b/en/reference/testing.html
@@ -97,7 +97,9 @@ $ mvn test -Dtest.categories=system
 
 <pre>
 -Dtest.categories=system
--Dtenant=mytenant
+-Dtenant=my_tenant
+-Dapplication=my_app
+-Dinstance=my_instance
 -DapiKeyFile=/path/to/myname.mytenant.pem
 -DdataPlaneCertificateFile=data-plane-public-cert.pem
 -DdataPlaneKeyFile=data-plane-private-key.pem


### PR DESCRIPTION
It looks like the testing framework pick up username as instance, which it should not. Hence users should always provide instance name, added app name for completeness (app and tenant often set in pom.xml, but complicates doc with this, it will always work when testing in IDE)