### PR TITLE
Allow for timestamps in status messages for more precision

### DIFF
--- a/_data/status.yml
+++ b/_data/status.yml
@@ -30,11 +30,12 @@ messages:
   # Detailed operational messages displayed below status overview. Use ISO 8601 formatted date; time is optional.
   # The HTML page will only show messages < 7 days old while JSON will include everything.
   # Add messages to the end, /status and console will sort with newest first regardless
+  # NOTE: Dates must be surrounded by quotes!
   # Example:
-  # - date: 2020-02-20T20:00Z
+  # - date: "2020-02-20T20:00Z"
   #   message: "Issues with query serving in aws.us-east-1c - currently investigating."
   #   status: warning
-  # - date: 2020-02-19
+  # - date: "2020-02-19"
   #   message: "All systems are go!"
   #   status: success
   - date: "2020-03-23"

--- a/_data/status.yml
+++ b/_data/status.yml
@@ -27,30 +27,37 @@ zones:
     status: success
     message: "OK"
 messages:
-  # Detailed operational messages displayed below status overview. The HTML page will only show 
-  # messages < 7 days old while JSON will include everything.
+  # Detailed operational messages displayed below status overview. Use ISO 8601 formatted date; time is optional.
+  # The HTML page will only show messages < 7 days old while JSON will include everything.
   # Add messages to the end, /status and console will sort with newest first regardless
   # Example:
-  # - date: 2020-02-20
+  # - date: 2020-02-20T20:00Z
   #   message: "Issues with query serving in aws.us-east-1c - currently investigating."
-  - date: 2020-03-23
+  #   status: warning
+  # - date: 2020-02-19
+  #   message: "All systems are go!"
+  #   status: success
+  - date: "2020-03-23"
     message: "The aws-ap-northeast-1a zone in Tokyo, JP region is now online!"
     status: success
-  - date: 2020-06-26
+  - date: "2020-06-26"
     message: "Builds are now working correctly."
     status: success
-  - date: 2020-10-21
+  - date: "2020-10-21"
     message: |
       A DNS issue in one AWS zone is causing intermittent failures in provisioning new nodes in test zones and aws-us-east-1c.
       Work around test zone problems by deploying without tests in the Vespa Console.
       The Vespa Team has implemented a fix, expected to roll out Monday 26. October.
     status: warning
-  - date: 2020-10-26
+  - date: "2020-10-26"
     message: Underlying issue has been fixed and all services are back to normal.
     status: success
-  - date: 2021-02-11
+  - date: "2021-02-11"
     message: "The aws-us-west-2a and aws-eu-west-1a zones are now online!"
     status: success
-  - date: 2021-03-24
+  - date: "2021-03-24T12:08Z"
+    message: "Issues with certificate issuer: Impact is that no new applications can be deployed to Vespa Cloud."
+    status: warning
+  - date: "2021-03-24T17:06Z"
     message: "External certificate issuer problem has been resolved: New applications can now be deployed again."
     status: success

--- a/_plugins/utc_filter.rb
+++ b/_plugins/utc_filter.rb
@@ -1,0 +1,9 @@
+module Jekyll
+  module UTCFilter
+    def to_utc(date)
+      time(date).utc
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::UTCFilter)

--- a/status.html
+++ b/status.html
@@ -11,61 +11,75 @@ layout: page
             }
 </style>
 
-            <p>Last updated: {{ site.time }}</p>
+            <p>Last updated: {{ site.time | to_utc | date: '%Y-%m-%d %H:%M %Z' }}</p>
             <p>
                 <table class="table">
                     <thead>
                         <tr><th><p>Zone</p></th><th><p>Status</p></th></tr>
                     </thead>
-                    {% if site.data.status.zones.size > 0 %}
+                    {%- if site.data.status.zones.size > 0 -%}
                     <tbody>
-                        {% for zone in site.data.status.zones %}
-                        {% assign status_lc = zone.status | lc %}
+                        {%- for zone in site.data.status.zones -%}
+                        {%- assign status_lc = zone.status | lc -%}
                         <tr>
                             <td>{{ zone.name }}</td>
                             <td>
-                                {% if status_lc == 'success' %}
+                                {%- if status_lc == 'success' -%}
                                 <span class="d-icon d-check" style="color:#0c0"></span>
-                                {% else %}
+                                {%- else -%}
                                 <span class="d-icon d-warning" style="color:#f90"></span>
-                                {% endif %}
+                                {%- endif -%}
                                 {{ zone.message }}
                             </td>
                         </tr>
-                        {% endfor %}
+                        {%- endfor -%}
                     </tbody>
-                    {% endif %}
+                    {%- endif -%}
                 </table>
             </p>
 
-            <h3>Messages</h3>
+            <h3>Messages (last 30 days)</h3>
             <div style="overflow: auto">
-            {% if site.data.status.messages[0] %}
-            {% assign datelimit = 'now' | date: '%s' | minus:604800000 %}
-            {% assign sorted_messages = site.data.status.messages | sort: 'date' | reverse %}
+            {%- assign num_messages = 0 -%}
+            {%- if site.data.status.messages[0] -%}
+            {%- assign datelimit = 'now' | date: '%s' | minus:259200 -%}
+            {%- assign sorted_messages = site.data.status.messages | sort: 'date' | reverse -%}
             <table class="table">
-            {% for message in sorted_messages %}
-                {% assign epoch = message.date | date: '%s' | ceil %}
-                {% if epoch >= datelimit %}
+            {%- for message in sorted_messages -%}
+                {%- assign timestamp = message.date | date: '%s' | ceil -%}
+                {%- assign date = message.date | date: '%Y-%m-%d' -%}
+                {%- assign time = message.date | date: '%R %Z' -%}
+                {%- assign hour = message.date | date: '%k' -%}
+                {%- assign minutes = message.date | date: '%M' -%}
+                {%- if timestamp >= datelimit -%}
+                {%- assign num_messages = num_message | plus: 1 -%}
                 <tr>
-                    <td style="white-space: nowrap; width: 100px">{{ message.date }}</td>
+                    <td style="white-space: nowrap; width: 100px">
+                        {{ date }}
+                        {%- if hour != '0' and minutes != '00' -%}
+                        <br>({{time}})
+                        {%- endif -%}
+                    </td>
                     <td>
-                    {% if message.status == 'success' %}
+                    {%- if message.status == 'success' -%}
                     <span class="d-icon d-check" style="color:#0c0"></span>
-                    {% else %}
+                    {%- else -%}
                     <span class="d-icon d-warning" style="color:#f90"></span>
-                    {% endif %}
+                    {%- endif -%}
                     </td>
                     <td>
                     {{ message.message }}
                     </td>
                 </tr>
-                {% endif %}
-            {% endfor %}
+                {%- endif -%}
+            {%- endfor -%}
+            {%- if num_messages == 0 -%}
+                <tr><td numspan="3">No updates.</td></tr>
+            {%- endif -%}
             </table>
-            {% else %}
+            {%- else -%}
             <p>
                 No updates.
             </p>
-            {% endif %}
+            {%- endif -%}
             </div>


### PR DESCRIPTION
@bratseth / @kkraune : We can still do more styling to make it look better, but this gives us the functionality to (optionally) include time in status messages for more precision.