### PR TITLE
Update link to metrics-emitter doc

### DIFF
--- a/en/monitoring.html
+++ b/en/monitoring.html
@@ -117,4 +117,6 @@ or that some part of the configuration is wrong.
 
 <h2>Using AWS Cloudwatch</h2>
 
-<p>Refer to the <a  href="https://github.com/vespa-engine/metrics-emitter">metrics-emitter</a>.</p>
+<p>To pull metrics from your Vespa application into AWS Cloudwatch, refer to the
+<a  href="https://github.com/vespa-engine/metrics-emitter/tree/master/cloudwatch">metrics-emitter</a> documentation
+for how to set up an AWS Lambda.</p>


### PR DESCRIPTION
Link directly to Cloudwatch subdir in metrics-emitter (top level README very light-weight) and add a bit more text around link.

@kkraune please review.