### PR TITLE
Revert "Update documentation for apiKeys in guide"

### DIFF
--- a/en/getting-started-java.html
+++ b/en/getting-started-java.html
@@ -59,9 +59,7 @@ $ cp data-plane-public-cert.pem src/main/application/security/clients.pem
     <p>
       In the console <a href="http://console.vespa.ai">console.vespa.ai</a>,
       choose tenant and click <em>Keys</em> to generate and save the <em>user API key</em>.
-      The key is generated in the browser and appears as two file downloads; the public
-      and the private key.  The files are named <code>USER.TENANTNAME.pub.pem</code> for the
-      public key and <code>USER.TENANTNAME.priv.pem</code> for the private key.
+      The key is saved to <code>$HOME/Downloads/USER.TENANTNAME.pem</code>.
     </p>
   </li>
 
@@ -78,7 +76,7 @@ $ cp data-plane-public-cert.pem src/main/application/security/clients.pem
     <p>
       This deploys an instance (with a name you choose here) of the application to the <code>dev</code> zone:
 <pre>
-$ mvn package vespa:deploy -DapiKeyFile=$HOME/Downloads/USER.TENANTNAME.priv.pem -Dinstance=my-instance
+$ mvn package vespa:deploy -DapiKeyFile=$HOME/Downloads/USER.TENANTNAME.pem -Dinstance=my-instance
 </pre>
 <!-- Version of the above for automatic testing -->    
 <pre data-test="exec" style="display:none">

--- a/en/getting-to-production.html
+++ b/en/getting-to-production.html
@@ -103,7 +103,7 @@ redirect_from: /getting-to-production.html
 <li>
   <p>Add the Vespa Cloud compile version to the application package:</p>
 <pre>
-$ mvn vespa:compileVersion -DapiKeyFile=$HOME/Downloads/USER.TENANTNAME.priv.pem
+$ mvn vespa:compileVersion -DapiKeyFile=$HOME/Downloads/TENANTNAME.pem
 </pre>
 </li>
 
@@ -117,7 +117,7 @@ $ mvn package -Dvespa.compile.version="$(cat target/vespa.compile.version)"
 <li>
   <p>Submit the application package to Vespa Cloud for deployment:</p>
 <pre>
-$ mvn vespa:submit -DapiKeyFile=$HOME/Downloads/USER.TENANTNAME.priv.pem
+$ mvn vespa:submit -DapiKeyFile=$HOME/Downloads/TENANTNAME.pem
 </pre>
 
   <p>


### PR DESCRIPTION
Reverts vespa-engine/cloud#310

Console now downloads only the private key, name `USER.TENANTNAME.pem` and has a separate download button to download the public key (named `USER.TENANTNAME.pub.pem`. See VESPA-20874.